### PR TITLE
Fetch full history for repo age linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@master
         with:
           node-version: 12.x


### PR DESCRIPTION
The `actions/checkout` action by default fetches only most recent snapshot of the repo.